### PR TITLE
Fixes install command typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 ## Installation
 
 ```sh
-npm install wallace-cli
+npm install -g wallace-cli
 ```
 
 ## Usage


### PR DESCRIPTION
Pretty sure it needs to be installed globally for the following example commands to work.