### PR TITLE
use Node `parseArgs` for parsing CLI arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "performance"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=18"
   },
   "scripts": {
     "pretest": "npm run build",


### PR DESCRIPTION
closes #116

~~I do wonder if it's worth the breaking change though, I'll sleep on it.~~ Lol, it's not breaking!