### PR TITLE
Make tests pass on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# keep test files EOL on checkout
+/src/__fixtures__/*.css text eol=lf
+/src/__fixtures__/*.txt text eol=lf


### PR DESCRIPTION
When there is no git global setting for `aoutocrlf`, git checkouts files with `EOL`s accordingly to the platform.
On Windows with `CRLF` tests become broken.

Using platform's `EOL`s does not completely help.
```javascript
// src/components.ts
import { EOL } from 'node:os'
[...].join(/*'\n' -> */ EOL)
```
Snapshots have file size in them which differs because `CRLF` is two chars.
```
# Heading output for `bol-dot-com.css`
───────────────────────────────────────────────────────────
Lines of Code │ Filesize │ Rules │ Selectors │ Declarations
17,818        │ 468.9KB  │ 4,757 │ 6,664     │ 10,083  <-- size in file content
17,818        │ 469KB    │ 4,757 │ 6,664     │ 10,083  <-- actual file size (when CRLF)
───────────────────────────────────────────────────────────
```

Adding explicit line endings for the test files in `.gitattributes` makes tests pass on Windows.